### PR TITLE
By default, Id columns are strings, not integers

### DIFF
--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -195,12 +195,17 @@ class InMemoryEntityManager implements EntityManagerInterface
                 continue;
             }
             $idField = $repo->getIdField();
+            $idType = $repo->getIdType();
             assert($idField !== null);
             $rp = new \ReflectionProperty($className, $idField);
             $rp->setAccessible(true);
             foreach ($entities as $entity) {
                 if ($rp->getValue($entity) === null) {
-                    $rp->setValue($entity, random_int(0, PHP_INT_MAX));
+                    $id = random_int(0, PHP_INT_MAX);
+                    if ($idType === 'string') {
+                        $id = (string) $id;
+                    }
+                    $rp->setValue($entity, $id);
                 }
             }
         }

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -9,6 +9,7 @@ use ReflectionClass;
 use TypeError;
 use UnexpectedValueException;
 use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
 
 /**
  * @template Entity of object
@@ -25,6 +26,9 @@ class InMemoryRepository implements ObjectRepository
 
     /** @var ?string */
     private $idField;
+
+    /** @var ?string */
+    private $idType;
 
     /** @var bool */
     private $isIdGenerated;
@@ -45,6 +49,7 @@ class InMemoryRepository implements ObjectRepository
         $this->rc = new ReflectionClass($fqcn);
         [
             $this->idField,
+            $this->idType,
             $this->isIdGenerated
         ] = $this->findIdField();
         // TODO: define behavior of non-int generated id fields
@@ -262,7 +267,7 @@ class InMemoryRepository implements ObjectRepository
      * Searches for an @Id tag on the entity, and returns a tuple containing
      * the associated property name and whether the value is generated.
      *
-     * @return array{string|null, bool}
+     * @return array{string|null, string|null, bool}
      */
     private function findIdField(): array
     {
@@ -271,13 +276,28 @@ class InMemoryRepository implements ObjectRepository
             assert($docComment !== false);
             $docblock = $this->docblockFactory->create($docComment);
             if ($docblock->hasTag('Id')) {
+                $idType = 'int';
+                $columnTags = $docblock->getTagsByName('Column');
+                if (count($columnTags) > 0) {
+                    $columnTag = $columnTags[0];
+                    assert($columnTag instanceof BaseTag);
+                    $desc = $columnTag->getDescription();
+                    if ($desc !== null) {
+                        $descString = $desc->render();
+                        $matchCount = preg_match('#type="([a-z]+)"#', $descString, $matches);
+                        if ($matchCount > 0) {
+                            $idType = $matches[1];
+                        }
+                    }
+                }
                 return [
                     $reflectionProp->getName(),
+                    $idType,
                     $docblock->hasTag('GeneratedValue'),
                 ];
             }
         }
-        return [null, false];
+        return [null, null, false];
     }
 
     /**
@@ -289,6 +309,17 @@ class InMemoryRepository implements ObjectRepository
     public function getIdField(): ?string
     {
         return $this->idField;
+    }
+
+    /**
+     * This is used to generate identifiers when flush() is called. It should
+     * not be used except by the EntityManager.
+     *
+     * @internal
+     */
+    public function getIdType(): ?string
+    {
+        return $this->idType;
     }
 
     /**

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -276,7 +276,9 @@ class InMemoryRepository implements ObjectRepository
             assert($docComment !== false);
             $docblock = $this->docblockFactory->create($docComment);
             if ($docblock->hasTag('Id')) {
-                $idType = 'int';
+                // If an Id Column doesn't have type="integer" it defaults to
+                // string (like all other columns)
+                $idType = 'string';
                 $columnTags = $docblock->getTagsByName('Column');
                 if (count($columnTags) > 0) {
                     $columnTag = $columnTags[0];
@@ -287,6 +289,14 @@ class InMemoryRepository implements ObjectRepository
                         $matchCount = preg_match('#type="([a-z]+)"#', $descString, $matches);
                         if ($matchCount > 0) {
                             $idType = $matches[1];
+                            if ($idType !== 'string' && $idType !== 'integer') {
+                                throw new UnexpectedValueException(sprintf(
+                                    'Detected Id type is %s, only %s and %s are valid',
+                                    $idType,
+                                    'string',
+                                    'integer'
+                                ));
+                            }
                         }
                     }
                 }

--- a/tests/Entities/StringId.php
+++ b/tests/Entities/StringId.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine\Entities;
+
+/**
+ * @Entity
+ * @Table(name="string_ids")
+ */
+class StringId
+{
+    /**
+     * @Id
+     * @Column(type="string")
+     * @GeneratedValue
+     * @var ?string
+     */
+    private $id;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/tests/Entities/User.php
+++ b/tests/Entities/User.php
@@ -11,7 +11,7 @@ class User
 {
     /**
      * @Id
-     * @Column
+     * @Column(type="integer")
      * @GeneratedValue
      * @var ?int
      */

--- a/tests/InMemoryEntityManagerTest.php
+++ b/tests/InMemoryEntityManagerTest.php
@@ -153,4 +153,19 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($flushed1, 'First callback did not fire');
         $this->assertTrue($flushed2, 'Second callback did not fire');
     }
+
+    /**
+     * @covers ::persist
+     * @covers ::flush
+     */
+    public function testStringIdIsGenerated(): void
+    {
+        $sid = new Entities\StringId();
+        $this->assertNull($sid->getId());
+        $em = new InMemoryEntityManager();
+        $em->persist($sid);
+        $em->flush();
+        $this->assertNotNull($sid->getId());
+        $this->assertIsString($sid->getId());
+    }
 }

--- a/tests/InMemoryEntityManagerTest.php
+++ b/tests/InMemoryEntityManagerTest.php
@@ -168,4 +168,19 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($sid->getId());
         $this->assertIsString($sid->getId());
     }
+
+    /**
+     * @covers ::persist
+     * @covers ::flush
+     */
+    public function testUnspecifiedIdIsString(): void
+    {
+        $sid = new Entities\UnspecifiedId();
+        $this->assertNull($sid->getId());
+        $em = new InMemoryEntityManager();
+        $em->persist($sid);
+        $em->flush();
+        $this->assertNotNull($sid->getId());
+        $this->assertIsString($sid->getId());
+    }
 }


### PR DESCRIPTION
Doctrine will cast the insert ID to a string unless you explicitly declare `@Column(type="integer")`. This ensures that simulated IDs from flush have the same behavior.