### PR TITLE
Move remaining sort/filter logic to criteria evaluation class

### DIFF
--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -30,11 +30,16 @@ use function str_ends_with;
 use function str_starts_with;
 
 /**
+ * This functions similarly to ClosureExpressionVisitor, but uses class
+ * reflection rather than a series of cascading accessor detectors (which are
+ * potentially unsafe and do not translate 1:1 with the ORM's behavior) to find
+ * and compare property values.
+ *
  * @template Entity of object
  *
  * @internal
  */
-class ExpressionMatcher
+class CriteriaEvaluator
 {
     /** @var class-string<Entity> */
     private string $className;

--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -76,7 +76,6 @@ class CriteriaEvaluator
         $entities = $this->match($expr);
 
         if ($orderings = $criteria->getOrderings()) {
-            /** @var array<string, Criteria::ASC|Criteria::DESC> $orderings */
             $entities = $this->sortResults($entities, $orderings);
         }
 
@@ -251,7 +250,8 @@ class CriteriaEvaluator
 
     /**
      * @param Entity[] $results
-     * @param array<array-key, Criteria::ASC|Criteria::DESC> $orderBy
+     * @param array<string, string> $orderBy (actually
+     * Criteria::ASC|Criteria:::DESC but the PHPStan annotations won't work)
      * @return Entity[]
      */
     private function sortResults(array $results, array $orderBy): array
@@ -285,6 +285,10 @@ class CriteriaEvaluator
                     } else {
                         return -1;
                     }
+                } else {
+                    // @codeCoverageIgnoreStart
+                    throw new DomainException(sprintf('Unhandled direction %s', $direction));
+                    // @codeCoverageIgnoreEnd
                 }
             }
             // If all loops have exited without returning a comparision

--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\Mocktrine;
 
 use BadMethodCallException;
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\{
     Comparison,
     CompositeExpression,
@@ -69,7 +70,33 @@ class CriteriaEvaluator
     /**
      * @return Entity[]
      */
-    public function match(?Expression $expr): array
+    public function evaluate(Criteria $criteria): array
+    {
+        $expr = $criteria->getWhereExpression();
+        $entities = $this->match($expr);
+
+        if ($orderings = $criteria->getOrderings()) {
+            /** @var array<string, Criteria::ASC|Criteria::DESC> $orderings */
+            $entities = $this->sortResults($entities, $orderings);
+        }
+
+        if ($offset = $criteria->getFirstResult()) {
+            $entities = array_slice($entities, $offset);
+        }
+
+        if ($limit = $criteria->getMaxResults()) {
+            $entities = array_slice($entities, 0, $limit);
+        }
+
+        return $entities;
+    }
+
+    /**
+     * Evaluates the where expression of the criteria
+     *
+     * @return Entity[]
+     */
+    private function match(?Expression $expr): array
     {
         if ($expr instanceof Comparison) {
             $comparitor = $this->matchComparison($expr);
@@ -222,5 +249,50 @@ class CriteriaEvaluator
         $propVal = $rp->getValue($entity);
         // $rp->setAccessible($isAccessible);
         return $propVal;
+    }
+
+    /**
+     * @param Entity[] $results
+     * @param array<array-key, Criteria::ASC|Criteria::DESC> $orderBy
+     * @return Entity[]
+     */
+    private function sortResults(array $results, array $orderBy): array
+    {
+        // WARNING: this has the potential to get quite slow due to the use
+        // of reflection on TWO entities on every single comparision. On
+        // typical test datasets this is unlikely to be a major issue, but
+        // it's quite inefficient and should be re-examined in the future.
+        /**
+         * @param Entity $a
+         * @param Entity $b
+         */
+        usort($results, function ($a, $b) use ($orderBy) {
+            foreach ($orderBy as $propName => $direction) {
+                $v1 = $this->getValueOfProperty($a, $propName);
+                $v2 = $this->getValueOfProperty($b, $propName);
+                if ($v1 === $v2) {
+                    // Don't return 0 - that's only safe if on the last
+                    // property in the sorting criteria
+                    continue;
+                }
+                if ($direction === Criteria::ASC) {
+                    if ($v1 > $v2) {
+                        return 1;
+                    } else {
+                        return -1;
+                    }
+                } elseif ($direction === Criteria::DESC) {
+                    if ($v1 < $v2) {
+                        return 1;
+                    } else {
+                        return -1;
+                    }
+                }
+            }
+            // If all loops have exited without returning a comparision
+            // result, all of the sort properties should be equal.
+            return 0;
+        });
+        return $results;
     }
 }

--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -216,8 +216,6 @@ class CriteriaEvaluator
     }
 
     /**
-     * FIXME: copied from InMemoryRepository
-     *
      * @param Entity $entity
      * @return mixed
      */

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -219,40 +219,6 @@ class InMemoryRepository implements ObjectRepository, Selectable
     }
 
     /**
-     * @param Entity $entity
-     * @return mixed
-     */
-    private function getValueOfProperty(object $entity, string $property)
-    {
-        if (!$this->rc->hasProperty($property)) {
-            throw new UnexpectedValueException(sprintf(
-                'Property "%s" does not exist on class "%s"',
-                $property,
-                $this->getClassName()
-            ));
-        }
-        $rp = $this->rc->getProperty($property);
-
-        $docComment = $rp->getDocComment();
-        assert($docComment !== false);
-        $docblock = $this->docblockFactory->create($docComment);
-        // TODO: suppport other relations
-        if (!$docblock->hasTag('Column')) {
-            throw new UnexpectedValueException(sprintf(
-                'Property "%s" is not a mapped field on class "%s"',
-                $property,
-                $this->getClassName()
-            ));
-        }
-
-        // $isAccessible = $rp->isPublic();
-        $rp->setAccessible(true);
-        $propVal = $rp->getValue($entity);
-        // $rp->setAccessible($isAccessible);
-        return $propVal;
-    }
-
-    /**
      * Searches for an @Id tag on the entity, and returns a tuple containing
      * the associated property name and whether the value is generated.
      *

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -214,22 +214,8 @@ class InMemoryRepository implements ObjectRepository, Selectable
     {
         $expr = $criteria->getWhereExpression();
 
-        $matcher = new CriteriaEvaluator($this->getClassName(), $this->managedEntities);
-        $entities = $matcher->match($expr);
-
-        if ($orderings = $criteria->getOrderings()) {
-            $entities = $this->sortResults($entities, $orderings);
-        }
-
-        if ($offset = $criteria->getFirstResult()) {
-            $entities = array_slice($entities, $offset);
-        }
-
-        if ($limit = $criteria->getMaxResults()) {
-            $entities = array_slice($entities, 0, $limit);
-        }
-
-        return $entities;
+        return (new CriteriaEvaluator($this->getClassName(), $this->managedEntities))
+            ->evaluate($criteria);
     }
 
     /**
@@ -264,56 +250,6 @@ class InMemoryRepository implements ObjectRepository, Selectable
         $propVal = $rp->getValue($entity);
         // $rp->setAccessible($isAccessible);
         return $propVal;
-    }
-
-    /**
-     * @param Entity[] $results
-     * @param array<array-key, string> $orderBy
-     * @return Entity[]
-     */
-    private function sortResults(array $results, array $orderBy): array
-    {
-        // WARNING: this has the potential to get quite slow due to the use
-        // of reflection on TWO entities on every single comparision. On
-        // typical test datasets this is unlikely to be a major issue, but
-        // it's quite inefficient and should be re-examined in the future.
-        /**
-         * @param Entity $a
-         * @param Entity $b
-         */
-        usort($results, function ($a, $b) use ($orderBy) {
-            foreach ($orderBy as $propName => $direction) {
-                $v1 = $this->getValueOfProperty($a, $propName);
-                $v2 = $this->getValueOfProperty($b, $propName);
-                if ($v1 === $v2) {
-                    // Don't return 0 - that's only safe if on the last
-                    // property in the sorting criteria
-                    continue;
-                }
-                if ($direction === Criteria::ASC) {
-                    if ($v1 > $v2) {
-                        return 1;
-                    } else {
-                        return -1;
-                    }
-                } elseif ($direction === Criteria::DESC) {
-                    if ($v1 < $v2) {
-                        return 1;
-                    } else {
-                        return -1;
-                    }
-                } else {
-                    // Should be unreachable
-                    // @codeCoverageIgnoreStart
-                    throw ORMException::invalidOrientation($this->getClassName(), $propName);
-                    // @codeCoverageIgnoreEnd
-                }
-            }
-            // If all loops have exited without returning a comparision
-            // result, all of the sort properties should be equal.
-            return 0;
-        });
-        return $results;
     }
 
     /**

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -214,7 +214,7 @@ class InMemoryRepository implements ObjectRepository, Selectable
     {
         $expr = $criteria->getWhereExpression();
 
-        $matcher = new ExpressionMatcher($this->getClassName(), $this->managedEntities);
+        $matcher = new CriteriaEvaluator($this->getClassName(), $this->managedEntities);
         $entities = $matcher->match($expr);
 
         if ($orderings = $criteria->getOrderings()) {

--- a/tests/CriteriaEvaluatorTest.php
+++ b/tests/CriteriaEvaluatorTest.php
@@ -13,7 +13,7 @@ use Firehed\Mocktrine\Entities\GrabBag;
  * @covers ::<protected>
  * @covers ::<private>
  * @covers ::__construct
- * @covers ::match
+ * @covers ::evaluate
  */
 class CriteriaEvaluatorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/CriteriaEvaluatorTest.php
+++ b/tests/CriteriaEvaluatorTest.php
@@ -9,13 +9,13 @@ use Doctrine\Common\Collections\Criteria;
 use Firehed\Mocktrine\Entities\GrabBag;
 
 /**
- * @coversDefaultClass Firehed\Mocktrine\ExpressionMatcher
+ * @coversDefaultClass Firehed\Mocktrine\CriteriaEvaluator
  * @covers ::<protected>
  * @covers ::<private>
  * @covers ::__construct
  * @covers ::match
  */
-class ExpressionMatcherTest extends \PHPUnit\Framework\TestCase
+class CriteriaEvaluatorTest extends \PHPUnit\Framework\TestCase
 {
     /** @var InMemoryRepository<GrabBag> */
     private InMemoryRepository $repo;


### PR DESCRIPTION
This de-duplicates the last of the logic, and eliminates a redundant implementation of `getValueOfProperty`, paving the way for optimizations and additional features.