### PR TITLE
Performance optimizations

### DIFF
--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -131,7 +131,6 @@ class CriteriaEvaluator
         } else {
             throw new DomainException(sprintf('Unknown expression class %s', get_class($expr)));
         }
-        return $entities;
     }
 
     /**

--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -75,7 +75,7 @@ class CriteriaEvaluator
     public function evaluate(Criteria $criteria): array
     {
         $expr = $criteria->getWhereExpression();
-        $entities = $this->match($expr);
+        $entities = $this->match($this->entities, $expr);
 
         if ($orderings = $criteria->getOrderings()) {
             $entities = $this->sortResults($entities, $orderings);
@@ -95,24 +95,25 @@ class CriteriaEvaluator
     /**
      * Evaluates the where expression of the criteria
      *
+     * @param Entity[] $entities
      * @return Entity[]
      */
-    private function match(?Expression $expr): array
+    private function match(array $entities, ?Expression $expr): array
     {
         if ($expr instanceof Comparison) {
             $comparitor = $this->matchComparison($expr);
-            $entities = array_filter(
-                $this->entities,
+            return array_filter(
+                $entities,
                 fn ($e) => $comparitor($this->getValueOfProperty($e, $expr->getField()))
             );
         } elseif ($expr instanceof CompositeExpression) {
-            $entities = $this->matchCompositeExpression($expr);
+            return $this->matchCompositeExpression($entities, $expr);
         } elseif ($expr instanceof Value) {
             throw new BadMethodCallException(
                 'match() called with Expr\Value. Please file a bug including the criteria used.'
             );
         } elseif ($expr === null) {
-            $entities = $this->entities;
+            return $entities;
         } else {
             throw new DomainException(sprintf('Unknown expression class %s', get_class($expr)));
         }
@@ -174,46 +175,53 @@ class CriteriaEvaluator
     }
 
     /**
+     * @param Entity[] $entities
      * @return Entity[]
      */
-    private function matchCompositeExpression(CompositeExpression $expr): array
+    private function matchCompositeExpression(array $entities, CompositeExpression $expr): array
     {
-        $expressions = $expr->getExpressionList();
-        // For each expression in the composite, apply the filtering and gather
-        // the results.
-        $filteredEntitySets = array_map([$this, 'match'], $expressions);
-
-        // Reduce the result sets to a single result set based on the
-        // expression type:
-        // - AND returns only the items in every set (by strict comparision)
-        // - OR returns the unique set of items across all sets
         $type = $expr->getType();
         switch ($type) {
             case CompositeExpression::TYPE_AND:
-                // Conceptually, this is expressed by:
-                // $inAllSets = array_intersect(...$filteredEntitySets);
-                // but array_intersect stringifies each item and can't be used here.
-                return array_reduce(
-                    $filteredEntitySets,
-                    function ($carry, $item) {
-                        // First pass
-                        if ($carry === null) {
-                            return $item;
-                        }
-                        return array_filter(
-                            $carry,
-                            fn ($itemInCarry) => in_array($itemInCarry, $item, true),
-                        );
-                    },
-                );
+                return $this->matchCompositeAndExpression($entities, $expr);
             case CompositeExpression::TYPE_OR:
-                return array_reduce($filteredEntitySets, 'array_merge', []);
+                return $this->matchCompositeOrExpression($entities, $expr);
             default:
                 // Should be unreachable
                 // @codeCoverageIgnoreStart
                 throw new DomainException(sprintf('Unhandled composite expression type %s', $type));
                 // @codeCoverageIgnoreEnd
         }
+    }
+
+    /**
+     * @param Entity[] $entities
+     * @return Entity[]
+     */
+    private function matchCompositeOrExpression(array $entities, CompositeExpression $expr): array
+    {
+        $expressions = $expr->getExpressionList();
+        // For each expression in the composite, apply the filtering and gather
+        // the results.
+        $filteredEntitySets = array_map(fn ($expr) => $this->match($entities, $expr), $expressions);
+
+        return array_reduce($filteredEntitySets, 'array_merge', []);
+    }
+
+    /**
+     * @param Entity[] $entities
+     * @return Entity[]
+     */
+    private function matchCompositeAndExpression(array $entities, CompositeExpression $expr): array
+    {
+        $expressions = $expr->getExpressionList();
+        // This is effectively a reduce operation by intersecting the results
+        // of mapping match across the entities, but instead iterative reduces
+        // the set to match for performance reasons.
+        foreach ($expressions as $expression) {
+            $entities = $this->match($entities, $expression);
+        }
+        return $entities;
     }
 
     /**

--- a/src/CriteriaEvaluatorFactory.php
+++ b/src/CriteriaEvaluatorFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine;
+
+/**
+ * @template Entity of object
+ */
+class CriteriaEvaluatorFactory
+{
+    /** @var CriteriaEvaluator[] */
+    private static array $instances = [];
+
+    /**
+     * @param class-string<Entity> $className
+     * @return CriteriaEvaluator<Entity>
+     */
+    public static function getInstance(string $className): CriteriaEvaluator
+    {
+        if (!array_key_exists($className, self::$instances)) {
+            self::$instances[$className] = new CriteriaEvaluator($className);
+        }
+        return self::$instances[$className];
+    }
+}

--- a/src/CriteriaEvaluatorFactory.php
+++ b/src/CriteriaEvaluatorFactory.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Firehed\Mocktrine;
 
+use function array_key_exists;
+
 /**
  * @template Entity of object
+ *
+ * @internal
  */
 class CriteriaEvaluatorFactory
 {
-    /** @var CriteriaEvaluator[] */
+    /**
+     * @var array<class-string<Entity>, CriteriaEvaluator<Entity>>
+     */
     private static array $instances = [];
 
     /**
@@ -21,6 +27,7 @@ class CriteriaEvaluatorFactory
         if (!array_key_exists($className, self::$instances)) {
             self::$instances[$className] = new CriteriaEvaluator($className);
         }
+        // @phpstan-ignore-next-line (see #3273)
         return self::$instances[$className];
     }
 }

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -222,8 +222,8 @@ class InMemoryRepository implements ObjectRepository, Selectable
     {
         $expr = $criteria->getWhereExpression();
 
-        return (new CriteriaEvaluator($this->getClassName(), $this->managedEntities))
-            ->evaluate($criteria);
+        return (new CriteriaEvaluator($this->getClassName()))
+            ->evaluate($this->managedEntities, $criteria);
     }
 
     /**

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -222,6 +222,7 @@ class InMemoryRepository implements ObjectRepository, Selectable
     {
         $expr = $criteria->getWhereExpression();
 
+        // @phpstan-ignore-next-line (see #3273)
         return CriteriaEvaluatorFactory::getInstance($this->getClassName())
             ->evaluate($this->managedEntities, $criteria);
     }

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -222,7 +222,7 @@ class InMemoryRepository implements ObjectRepository, Selectable
     {
         $expr = $criteria->getWhereExpression();
 
-        return (new CriteriaEvaluator($this->getClassName()))
+        return CriteriaEvaluatorFactory::getInstance($this->getClassName())
             ->evaluate($this->managedEntities, $criteria);
     }
 

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -20,6 +20,14 @@ use UnexpectedValueException;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
 
+use function assert;
+use function count;
+use function current;
+use function is_array;
+use function preg_match;
+use function spl_object_hash;
+use function sprintf;
+
 /**
  * @template Entity of object
  *

--- a/tests/CriteriaEvaluatorFactoryTest.php
+++ b/tests/CriteriaEvaluatorFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine;
+
+/**
+ * @coversDefaultClass Firehed\Mocktrine\CriteriaEvaluatorFactory
+ * @covers ::<protected>
+ * @covers ::<private>
+ */
+class CriteriaEvaluatorFactoryTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetInstanceReturnsSingleton(): void
+    {
+        $ce1 = CriteriaEvaluatorFactory::getInstance(Entities\GrabBag::class);
+        $ce2 = CriteriaEvaluatorFactory::getInstance(Entities\GrabBag::class);
+
+        $this->assertSame(
+            $ce1,
+            $ce2,
+            'getInstance should return the same instance for a given class',
+        );
+    }
+
+    public function testGetInstanceReturnsDifferentInstancesForDifferentClasses(): void
+    {
+        $ce1 = CriteriaEvaluatorFactory::getInstance(Entities\GrabBag::class);
+        $ce2 = CriteriaEvaluatorFactory::getInstance(Entities\User::class);
+
+        $this->assertNotSame(
+            $ce1,
+            $ce2,
+            'getInstance should not return the same instance for different classes'
+        );
+    }
+}


### PR DESCRIPTION
Following the merging of `findBy` and `Selectable` (#17), there was a severe performance regression, where an external test suite that previously took ~32s  degraded to taking ~2:10 (about 4x slower).

These changes not only restore the original performance, but significantly improve it:
- inline entity filtering of `CompositeExpression`s of `TYPE_AND` restored the original performance (which impacts the majority-case of the `findBy()` family)
- re-use of `ReflectionProperty` objects reduced runtime by about 45% on the whole test suite (32s -> 22s), and a ~3x speedup on a test case class that very heavily relies on this library (15s -> 5s)
- switching to a per-class singleton of the criteria evaliator yielded an additional 30% runtime reduction (22s -> 17s) on the whole test suite

Overall, this should be a very, very significant performance improvement (about double from 0.3.0; and nearly an order of magnitude from HEAD) in most test suites, typically with an inconsequential amount of added memory used.