### PR TITLE
Make findBy sorting case-insensitive

### DIFF
--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -20,6 +20,9 @@ use UnexpectedValueException;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
 
+use function strtoupper;
+use function trim;
+
 /**
  * @template Entity of object
  *
@@ -156,6 +159,7 @@ class InMemoryRepository implements ObjectRepository, Selectable
             // Criteria::orderBy silently converts any invalid inputs to 'DESC'
             // This pre-validates them
             foreach ($orderBy as $field => $direction) {
+                $direction = strtoupper(trim($direction));
                 if ($direction !== Criteria::ASC && $direction !== Criteria::DESC) {
                     throw ORMException::invalidOrientation($this->getClassName(), $field);
                 }

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -99,6 +99,19 @@ class InMemoryRepositoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::findBy */
+    public function testFindBySortingIsCaseInsensitive(): void
+    {
+        $repo = $this->getFixture();
+        $results = $repo->findBy([], ['lastName' => 'asc', 'email' => 'dEsC']);
+        $this->assertResultSizeAndIndexValidity(5, $results);
+        $this->assertSame('2@example.com', $results[0]->getEmail());
+        $this->assertSame('1@example.com', $results[1]->getEmail());
+        $this->assertSame('5@example.com', $results[2]->getEmail());
+        $this->assertSame('4@example.com', $results[3]->getEmail());
+        $this->assertSame('3@example.com', $results[4]->getEmail());
+    }
+
+    /** @covers ::findBy */
     public function testFindByWithLimit(): void
     {
         $repo = $this->getFixture();


### PR DESCRIPTION
This matches Doctrine's internal implementation, so `asc` and `desc` work as expected.