### PR TITLE
Drop dependency of docblock parser library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "doctrine/collections": "^1.6",
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0",
-        "phpdocumentor/reflection-docblock": "^4.3 || ^5.0",
         "symfony/polyfill-php80": "^1.20"
     },
     "require-dev": {


### PR DESCRIPTION
Migrating to Doctrine's driver renders this unnecessary.