### PR TITLE
Update PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "symfony/polyfill-php80": "^1.20"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12.0",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,22 +1,67 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Array \\(array\\<class\\-string\\<Entity of object\\>, Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\>\\) does not accept Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\.$#"
+			message: "#^Return type \\(Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\) of method Firehed\\\\Mocktrine\\\\InMemoryEntityManager\\:\\:getRepository\\(\\) should be compatible with return type \\(Doctrine\\\\ORM\\\\EntityRepository\\<object\\>\\) of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getRepository\\(\\)$#"
 			count: 1
 			path: src/InMemoryEntityManager.php
 
 		-
-			message: "#^Array \\(array\\<class\\-string\\<Entity of object\\>, Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\>\\) does not accept key class\\-string\\<Entity of object\\>\\.$#"
+			message: "#^Property Firehed\\\\Mocktrine\\\\RepositoryContainer\\:\\:\\$values with generic class Firehed\\\\Mocktrine\\\\InMemoryRepository does not specify its types\\: Entity$#"
 			count: 1
-			path: src/InMemoryEntityManager.php
+			path: src/RepositoryContainer.php
 
 		-
-			message: "#^Method Firehed\\\\Mocktrine\\\\InMemoryEntityManager\\:\\:getRepository\\(\\) should return Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\> but returns Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\|Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\.$#"
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\GrabBag\\:\\:\\$boolField is never read, only written\\.$#"
 			count: 1
-			path: src/InMemoryEntityManager.php
+			path: tests/Entities/GrabBag.php
 
 		-
-			message: "#^Return type \\(Firehed\\\\Mocktrine\\\\InMemoryRepository\\<Entity of object\\>\\) of method Firehed\\\\Mocktrine\\\\InMemoryEntityManager\\:\\:getRepository\\(\\) should be compatible with return type \\(Doctrine\\\\ORM\\\\EntityRepository\\<mixed\\>\\) of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getRepository\\(\\)$#"
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\GrabBag\\:\\:\\$dateField is never read, only written\\.$#"
 			count: 1
-			path: src/InMemoryEntityManager.php
+			path: tests/Entities/GrabBag.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\GrabBag\\:\\:\\$floatField is never read, only written\\.$#"
+			count: 1
+			path: tests/Entities/GrabBag.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\GrabBag\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Entities/GrabBag.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\GrabBag\\:\\:\\$strField is never read, only written\\.$#"
+			count: 1
+			path: tests/Entities/GrabBag.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\StringId\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Entities/StringId.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\UnspecifiedId\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Entities/UnspecifiedId.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\User\\:\\:\\$active is never read, only written\\.$#"
+			count: 1
+			path: tests/Entities/User.php
+
+		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\User\\:\\:\\$notAColumn is never read, only written\\.$#"
+			count: 1
+			path: tests/Entities/User.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with false and 'First callback did…' will always evaluate to false\\.$#"
+			count: 1
+			path: tests/InMemoryEntityManagerTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with false and 'Second callback did…' will always evaluate to false\\.$#"
+			count: 1
+			path: tests/InMemoryEntityManagerTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
 parameters:
-    excludes_analyse:
+    excludePaths:
         - vendor
     level: max
     paths:

--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -118,7 +118,6 @@ class CriteriaEvaluator
 
     /**
      * @return callable(mixed $entityValue): bool
-     * xeturn Entity[]
      */
     private function matchComparison(Comparison $expr): callable
     {
@@ -153,15 +152,20 @@ class CriteriaEvaluator
             case Comparison::LTE:
                 return fn ($entVal) => $entVal <= $value;
             case Comparison::IN:
+                assert(is_array($value));
                 return fn ($entVal) => in_array($entVal, $value, true);
             case Comparison::NIN:
+                assert(is_array($value));
                 return fn ($entVal) => !in_array($entVal, $value, true);
             case Comparison::CONTAINS:
+                assert(is_string($value));
                 return fn ($entVal) => str_contains($entVal, $value);
             // TODO: case MEMBER_OF:
             case Comparison::STARTS_WITH:
+                assert(is_string($value));
                 return fn ($entVal) => str_starts_with($entVal, $value);
             case Comparison::ENDS_WITH:
+                assert(is_string($value));
                 return fn ($entVal) => str_ends_with($entVal, $value);
         }
         // Should be unreachable

--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -51,14 +51,12 @@ class InMemoryEntityManager implements EntityManagerInterface
     private MappingDriver $mappingDriver;
 
     /**
-     * @template Entity of object
-     * @var array<class-string<Entity>, array<Entity>>
+     * @var array<class-string, object[]>
      */
     private $needIds = [];
 
     /**
-     * @template Entity of object
-     * @var array<class-string<Entity>, array<Entity>>
+     * @var array<class-string, object[]>
      */
     private $pendingDeletes = [];
 
@@ -205,11 +203,6 @@ class InMemoryEntityManager implements EntityManagerInterface
      */
     public function flush()
     {
-        /**
-         * @template Entity of object
-         * @var class-string<Entity> $className
-         * @var Entity[] $entities
-         */
         foreach ($this->pendingDeletes as $className => $entities) {
             $repo = $this->getRepository($className);
             foreach ($entities as $entity) {
@@ -218,11 +211,6 @@ class InMemoryEntityManager implements EntityManagerInterface
         }
         $this->pendingDeletes = [];
 
-        /**
-         * @template Entity of object
-         * @var class-string<Entity> $className
-         * @var Entity[] $entities
-         */
         foreach ($this->needIds as $className => $entities) {
             $repo = $this->getRepository($className);
             if (!$repo->isIdGenerated()) {

--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -36,11 +36,8 @@ class InMemoryEntityManager implements EntityManagerInterface
     /**
      * This holds all of the InMemoryRepository objects, which will be lazily
      * instantiated as they are first used.
-     *
-     * @template Entity of object
-     * @var array<class-string<Entity>, InMemoryRepository<Entity>>
      */
-    private $repos = [];
+    private RepositoryContainer $repos;
 
     /**
      * Default instance, for performance
@@ -82,6 +79,7 @@ class InMemoryEntityManager implements EntityManagerInterface
             $driver = self::getDefaultMappingDriver();
         }
         $this->mappingDriver = $driver;
+        $this->repos = new RepositoryContainer();
     }
 
     public function addOnFlushCallback(callable $callback): void
@@ -259,12 +257,11 @@ class InMemoryEntityManager implements EntityManagerInterface
      */
     public function getRepository($className)
     {
-        // https://github.com/phpstan/phpstan/issues/2761
-        if (!isset($this->repos[$className])) {
-            $this->repos[$className] = new InMemoryRepository($className, $this->mappingDriver);
+        if (!$this->repos->has($className)) {
+            $this->repos->set($className, new InMemoryRepository($className, $this->mappingDriver));
         }
 
-        return $this->repos[$className];
+        return $this->repos->get($className);
     }
 
     /**

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -88,6 +88,7 @@ class InMemoryRepository implements ObjectRepository, Selectable
 
         assert(count($ids) === 1);
         $idField = $ids[0];
+        assert(is_string($idField));
         $this->idField = $idField;
         $idType = $metadata->getTypeOfField($idField);
         assert($idType !== null);

--- a/src/RepositoryContainer.php
+++ b/src/RepositoryContainer.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine;
+
+/**
+ * @internal
+ */
+class RepositoryContainer
+{
+    /**
+     * Broken generic ~ see https://github.com/phpstan/phpstan/issues/2761
+     * @var array<class-string, InMemoryRepository>
+     */
+    private $values = [];
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     * @return InMemoryRepository<T>
+     */
+    public function get(string $className): object
+    {
+        return $this->values[$className];
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     */
+    public function has(string $className): bool
+    {
+        return array_key_exists($className, $this->values);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     * @param InMemoryRepository<T> $repo
+     */
+    public function set(string $className, InMemoryRepository $repo): void
+    {
+        $this->values[$className] = $repo;
+    }
+}


### PR DESCRIPTION
This adds a couple of assertions for newer versions and a workaround for `array<class-string<T>, T>` being unsupported. Some entity-specific errors are added into the baseline.