### PR TITLE
Prevent crash when generating ids that have native type info

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,6 +41,11 @@ parameters:
 			path: tests/Entities/StringId.php
 
 		-
+			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\TypedId\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Entities/TypedId.php
+
+		-
 			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\UnspecifiedId\\:\\:\\$id is never written, only read\\.$#"
 			count: 1
 			path: tests/Entities/UnspecifiedId.php

--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -221,7 +221,7 @@ class InMemoryEntityManager implements EntityManagerInterface
             $rp = new \ReflectionProperty($className, $idField);
             $rp->setAccessible(true);
             foreach ($entities as $entity) {
-                if ($rp->getValue($entity) === null) {
+                if (!$rp->isInitialized($entity) || $rp->getValue($entity) === null) {
                     $id = random_int(0, PHP_INT_MAX);
                     if ($idType === 'string') {
                         $id = (string) $id;

--- a/tests/Entities/TypedId.php
+++ b/tests/Entities/TypedId.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine\Entities;
+
+use Doctrine\ORM\Mapping;
+
+/**
+ * @Entity
+ * @Table(name="typed_ids")
+ */
+#[Mapping\Entity]
+#[Mapping\Table(name: 'typed_ids')]
+class TypedId
+{
+    /**
+     * @Id
+     * @Column
+     * @GeneratedValue
+     */
+    #[Mapping\Id]
+    #[Mapping\Column]
+    #[Mapping\GeneratedValue]
+    private int $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Entities/XmlMappings/Firehed.Mocktrine.Entities.TypedId.dcm.xml
+++ b/tests/Entities/XmlMappings/Firehed.Mocktrine.Entities.TypedId.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="https://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Firehed\Mocktrine\Entities\TypedId" table="typed_ids">
+
+        <id name="id" type="int" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/InMemoryEntityManagerTest.php
+++ b/tests/InMemoryEntityManagerTest.php
@@ -138,6 +138,15 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
         $this->assertIsString($sid->getId());
     }
 
+    public function testTypedIdIsGenerated(): void
+    {
+        $tsid = new Entities\TypedId();
+        $em = $this->getEntityManager();
+        $em->persist($tsid);
+        $em->flush();
+        $this->assertIsInt($tsid->getId());
+    }
+
     public function testUnspecifiedIdIsString(): void
     {
         $sid = new Entities\UnspecifiedId();


### PR DESCRIPTION
Fixes #33 