### PR TITLE
Test interactions with readonly ids

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
         php:
           - '7.4'
           - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
 
     steps:
       - name: Check out code

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "doctrine/annotations": "^1.10",
-        "doctrine/collections": "^1.6",
+        "doctrine/collections": "^1.6.8",
         "doctrine/orm": "^2.9",
         "doctrine/persistence": "^1.3 || ^2.0",
         "symfony/polyfill-php80": "^1.20"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,6 +36,11 @@ parameters:
 			path: tests/Entities/GrabBag.php
 
 		-
+			message: "#^Class Firehed\\\\Mocktrine\\\\Entities\\\\ReadonlyGeneratedId has an uninitialized readonly property \\$id\\. Assign it in the constructor\\.$#"
+			count: 1
+			path: tests/Entities/ReadonlyGeneratedId.php
+
+		-
 			message: "#^Property Firehed\\\\Mocktrine\\\\Entities\\\\StringId\\:\\:\\$id is never written, only read\\.$#"
 			count: 1
 			path: tests/Entities/StringId.php

--- a/tests/Entities/ReadonlyConstructorId.php
+++ b/tests/Entities/ReadonlyConstructorId.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine\Entities;
+
+use Doctrine\ORM\Mapping;
+
+/**
+ * @Entity
+ * @Table(name="readonly_constructor_ids")
+ */
+#[Mapping\Entity]
+#[Mapping\Table(name: 'readonly_constructor_ids')]
+class ReadonlyConstructorId
+{
+    /**
+     * @Id
+     * @Column
+     */
+    #[Mapping\Id]
+    #[Mapping\Column]
+    public readonly string $id;
+
+    public function __construct()
+    {
+        // Normally this would be a UUID, ULID, etc.
+        $this->id = bin2hex(random_bytes(10));
+    }
+}

--- a/tests/Entities/ReadonlyGeneratedId.php
+++ b/tests/Entities/ReadonlyGeneratedId.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\Mocktrine\Entities;
+
+use Doctrine\ORM\Mapping;
+
+/**
+ * @Entity
+ * @Table(name="readonly_generated_ids")
+ */
+#[Mapping\Entity]
+#[Mapping\Table(name: 'readonly_generated_ids')]
+class ReadonlyGeneratedId
+{
+    /**
+     * @Id
+     * @Column
+     * @GeneratedValue
+     */
+    #[Mapping\Id]
+    #[Mapping\Column]
+    #[Mapping\GeneratedValue]
+    public readonly int $id;
+}

--- a/tests/Entities/XmlMappings/Firehed.Mocktrine.Entities.ReadonlyConstructorId.dcm.xml
+++ b/tests/Entities/XmlMappings/Firehed.Mocktrine.Entities.ReadonlyConstructorId.dcm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="https://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Firehed\Mocktrine\Entities\ReadonlyConstructorId" table="readonly_constructor_ids">
+
+        <id name="id" type="string" column="id" />
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Entities/XmlMappings/Firehed.Mocktrine.Entities.ReadonlyGeneratedId.dcm.xml
+++ b/tests/Entities/XmlMappings/Firehed.Mocktrine.Entities.ReadonlyGeneratedId.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="https://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Firehed\Mocktrine\Entities\ReadonlyGeneratedId" table="readonly_generated_ids">
+
+        <id name="id" type="int" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/InMemoryEntityManagerTest.php
+++ b/tests/InMemoryEntityManagerTest.php
@@ -182,4 +182,28 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
         $foundStringId = $em->find(Entities\StringId::class, $stringId->getId());
         $this->assertSame($foundStringId, $stringId);
     }
+
+    public function testGeneratedReadonlyIdWorks(): void
+    {
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $this->markTestSkipped('Readonly properties need 8.1+');
+        }
+        $rgid = new Entities\ReadonlyGeneratedId();
+        $em = $this->getEntityManager();
+        $em->persist($rgid);
+        $em->flush();
+        $this->assertIsInt($rgid->id);
+    }
+
+    public function testConstructorAssignedReadonlyIdWorks(): void
+    {
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $this->markTestSkipped('Readonly properties need 8.1+');
+        }
+        $rgid = new Entities\ReadonlyConstructorId();
+        $em = $this->getEntityManager();
+        $em->persist($rgid);
+        $em->flush();
+        $this->assertIsString($rgid->id);
+    }
 }


### PR DESCRIPTION
In newer PHP versions (which this expands the test matrix to cover), using `readonly` id properties is an option and, generally, a good one. This adds tests to ensure it mimics the expected behavior.