### PR TITLE
Expand supported versions of doctrine/annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ $driver = $config->getMetadataDriverImpl();
 $em = new Mocktrine\InMemoryEntityManager($driver)
 ```
 
-If a driver is not provided, it will default to the `SimpleAnnotationReader` that's used via `Setup::createAnnotationMetadataConfiguration`.
+If a driver is not provided, it will default to either `SimpleAnnotationReader` or `AnnotationReader` that's used via `Setup::createAnnotationMetadataConfiguration`.
+The former will be preferred, but the class has been removed in `doctrine/annotations:2.0`; if your local dependencies allow that version then the latter will be used.
 
 ## Supported features
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ $em = new Mocktrine\InMemoryEntityManager($driver)
 If a driver is not provided, it will default to either `SimpleAnnotationReader` or `AnnotationReader` that's used via `Setup::createAnnotationMetadataConfiguration`.
 The former will be preferred, but the class has been removed in `doctrine/annotations:2.0`; if your local dependencies allow that version then the latter will be used.
 
+It is RECOMMENDED to always explicitly provide a driver, as that best matches Doctrine's own setup behavior.
+Future versions of this library may make this required.
+
 ## Supported features
 
 The following methods on Doctrine's `EntityManagerInterface` should all work as expected:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/annotations": "^1.10",
+        "doctrine/annotations": "^1.10 || ^2.0",
         "doctrine/collections": "^1.6.8",
         "doctrine/orm": "^2.9",
         "doctrine/persistence": "^1.3 || ^2.0",

--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -661,6 +661,12 @@ class InMemoryEntityManager implements EntityManagerInterface
             // worry about the relative path to the vendor/ directory.
             class_exists(DoctrineAnnotations::class);
             if (class_exists(SimpleAnnotationReader::class)) {
+                /**
+                 * In Annotations:2.x, SimpleAnnotationReader was removed. This
+                 * re-adds the type info that won't be available in high
+                 * dependencies.
+                 * @var \Doctrine\Common\Annotations\Reader&SimpleAnnotationReader
+                 */
                 $reader = new SimpleAnnotationReader();
                 $reader->addNamespace('Doctrine\ORM\Mapping');
             } else {

--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\Mocktrine;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\ORM\{
     Configuration,
@@ -659,8 +660,12 @@ class InMemoryEntityManager implements EntityManagerInterface
             // the file through normal Composer autoloading and avoid having to
             // worry about the relative path to the vendor/ directory.
             class_exists(DoctrineAnnotations::class);
-            $reader = new SimpleAnnotationReader();
-            $reader->addNamespace('Doctrine\ORM\Mapping');
+            if (class_exists(SimpleAnnotationReader::class)) {
+                $reader = new SimpleAnnotationReader();
+                $reader->addNamespace('Doctrine\ORM\Mapping');
+            } else {
+                $reader = new AnnotationReader();
+            }
             self::$defaultMappingDriver = new AnnotationDriver($reader);
         }
         return self::$defaultMappingDriver;

--- a/tests/CriteriaEvaluatorTest.php
+++ b/tests/CriteriaEvaluatorTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Firehed\Mocktrine;
 
 use DateTimeImmutable;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Firehed\Mocktrine\Entities\GrabBag;
 
@@ -22,7 +24,8 @@ class CriteriaEvaluatorTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $em = new InMemoryEntityManager();
+        $reader = new AnnotationReader();
+        $em = new InMemoryEntityManager(new AnnotationDriver($reader));
         $repo = $em->getRepository(GrabBag::class);
         $this->entities = [
             new GrabBag(true, 30, 'hello', new DateTimeImmutable()),

--- a/tests/Entities/GrabBag.php
+++ b/tests/Entities/GrabBag.php
@@ -8,41 +8,41 @@ use DateTimeInterface;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="grab_bags")
+ * @Mapping\Entity
+ * @Mapping\Table(name="grab_bags")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'grab_bags')]
 class GrabBag
 {
     /**
-     * @Id
-     * @Column
+     * @Mapping\Id
+     * @Mapping\Column
      */
     #[Mapping\Id]
     #[Mapping\Column]
     private int $id;
 
     /**
-     * @Column(name="bool_field", type="boolean")
+     * @Mapping\Column(name="bool_field", type="boolean")
      */
     #[Mapping\Column]
     private bool $boolField;
 
     /**
-     * @Column(name="float_field", type="float")
+     * @Mapping\Column(name="float_field", type="float")
      */
     #[Mapping\Column]
     private float $floatField;
 
     /**
-     * @Column(name="str_field")
+     * @Mapping\Column(name="str_field")
      */
     #[Mapping\Column]
     private string $strField;
 
     /**
-     * @Column(name="date_field", type="date")
+     * @Mapping\Column(name="date_field", type="date")
      */
     #[Mapping\Column]
     private DateTimeInterface $dateField;

--- a/tests/Entities/Group.php
+++ b/tests/Entities/Group.php
@@ -7,8 +7,8 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="groups")
+ * @Mapping\Entity
+ * @Mapping\Table(name="groups")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'groups')]

--- a/tests/Entities/Node.php
+++ b/tests/Entities/Node.php
@@ -7,16 +7,16 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="nodes")
+ * @Mapping\Entity
+ * @Mapping\Table(name="nodes")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'nodes')]
 class Node
 {
     /**
-     * @Id
-     * @Column
+     * @Mapping\Id
+     * @Mapping\Column
      * @var string
      */
     #[Mapping\Id]

--- a/tests/Entities/ReadonlyConstructorId.php
+++ b/tests/Entities/ReadonlyConstructorId.php
@@ -7,16 +7,16 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="readonly_constructor_ids")
+ * @Mapping\Entity
+ * @Mapping\Table(name="readonly_constructor_ids")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'readonly_constructor_ids')]
 class ReadonlyConstructorId
 {
     /**
-     * @Id
-     * @Column
+     * @Mapping\Id
+     * @Mapping\Column
      */
     #[Mapping\Id]
     #[Mapping\Column]

--- a/tests/Entities/ReadonlyGeneratedId.php
+++ b/tests/Entities/ReadonlyGeneratedId.php
@@ -7,17 +7,17 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="readonly_generated_ids")
+ * @Mapping\Entity
+ * @Mapping\Table(name="readonly_generated_ids")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'readonly_generated_ids')]
 class ReadonlyGeneratedId
 {
     /**
-     * @Id
-     * @Column
-     * @GeneratedValue
+     * @Mapping\Id
+     * @Mapping\Column
+     * @Mapping\GeneratedValue
      */
     #[Mapping\Id]
     #[Mapping\Column]

--- a/tests/Entities/StringId.php
+++ b/tests/Entities/StringId.php
@@ -7,17 +7,17 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="string_ids")
+ * @Mapping\Entity
+ * @Mapping\Table(name="string_ids")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'string_ids')]
 class StringId
 {
     /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue
+     * @Mapping\Id
+     * @Mapping\Column(type="string")
+     * @Mapping\GeneratedValue
      * @var ?string
      */
     #[Mapping\Id]

--- a/tests/Entities/TypedId.php
+++ b/tests/Entities/TypedId.php
@@ -7,17 +7,17 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="typed_ids")
+ * @Mapping\Entity
+ * @Mapping\Table(name="typed_ids")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'typed_ids')]
 class TypedId
 {
     /**
-     * @Id
-     * @Column
-     * @GeneratedValue
+     * @Mapping\Id
+     * @Mapping\Column
+     * @Mapping\GeneratedValue
      */
     #[Mapping\Id]
     #[Mapping\Column]

--- a/tests/Entities/UnspecifiedId.php
+++ b/tests/Entities/UnspecifiedId.php
@@ -7,17 +7,17 @@ namespace Firehed\Mocktrine\Entities;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="unspecified_ids")
+ * @Mapping\Entity
+ * @Mapping\Table(name="unspecified_ids")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'unspecified_ids')]
 class UnspecifiedId
 {
     /**
-     * @Id
-     * @Column
-     * @GeneratedValue
+     * @Mapping\Id
+     * @Mapping\Column
+     * @Mapping\GeneratedValue
      * @var ?string
      */
     #[Mapping\Id]

--- a/tests/Entities/User.php
+++ b/tests/Entities/User.php
@@ -8,17 +8,17 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping;
 
 /**
- * @Entity
- * @Table(name="users")
+ * @Mapping\Entity
+ * @Mapping\Table(name="users")
  */
 #[Mapping\Entity]
 #[Mapping\Table(name: 'users')]
 class User
 {
     /**
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue
+     * @Mapping\Id
+     * @Mapping\Column(type="integer")
+     * @Mapping\GeneratedValue
      * @var ?int
      */
     #[Mapping\Id]
@@ -27,21 +27,21 @@ class User
     private $id;
 
     /**
-     * @Column
+     * @Mapping\Column
      * @var string
      */
     #[Mapping\Column]
     private $email;
 
     /**
-     * @Column(type="boolean")
+     * @Mapping\Column(type="boolean")
      * @var bool
      */
     #[Mapping\Column(type: Types::BOOLEAN)]
     private $active = false;
 
     /**
-     * @Column(name="last_name")
+     * @Mapping\Column(name="last_name")
      * @var string
      */
     #[Mapping\Column]

--- a/tests/InMemoryEntityManagerTest.php
+++ b/tests/InMemoryEntityManagerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Firehed\Mocktrine;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
@@ -14,7 +16,8 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
 {
     protected function getEntityManager(): InMemoryEntityManager
     {
-        return new InMemoryEntityManager();
+        $reader = new AnnotationReader();
+        return new InMemoryEntityManager(new AnnotationDriver($reader));
     }
 
     public function testFindWithNoEntity(): void

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Firehed\Mocktrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Persistence\ObjectRepository;
 use Doctrine\ORM\ORMException;

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\Mocktrine;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Persistence\ObjectRepository;
@@ -24,8 +25,12 @@ class InMemoryRepositoryTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $reader = new SimpleAnnotationReader();
-        $reader->addNamespace('Doctrine\ORM\Mapping');
+        if (class_exists(SimpleAnnotationReader::class)) {
+            $reader = new SimpleAnnotationReader();
+            $reader->addNamespace('Doctrine\ORM\Mapping');
+        } else {
+            $reader = new AnnotationReader();
+        }
         $this->driver = new AnnotationDriver($reader);
     }
 

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -25,12 +25,7 @@ class InMemoryRepositoryTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        if (class_exists(SimpleAnnotationReader::class)) {
-            $reader = new SimpleAnnotationReader();
-            $reader->addNamespace('Doctrine\ORM\Mapping');
-        } else {
-            $reader = new AnnotationReader();
-        }
+        $reader = new AnnotationReader();
         $this->driver = new AnnotationDriver($reader);
     }
 


### PR DESCRIPTION
This now supports v1 or v2 of the annotations package. v2 has dropped support for SimpleAnnotationReader; consequently, a bunch of the tests needed to be updated with different mappings to handle only the "full" annotation reader being present in that version.

The default driver now switches based on class presence, still generally matching Doctrine itself.  This should not be a BC break in practice since updating to that version would have already forced an eqiuivalent model update.