### PR TITLE
Add count method to InMemoryRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following methods on Doctrine's `EntityManagerInterface` should all work as 
 - getCache (will always return `null`)
 - isOpen (will always return `true`)
 
-All methods on the `ObjectRepository` (for various findBy operations) should also work.
+All methods on the `ObjectRepository` (for various findBy operations) should also work, as well as the non-interface `count($criteria)` method.
 `ObjectRepository` also implements the `Selectable` interface (as `EntityRepository` does, which is the returned type from `EntityManager`), so it's also possible to use the `matching(Criteria)` method.
 
 The following methods are **not** supported at this time:

--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -200,6 +200,19 @@ class InMemoryRepository implements ObjectRepository, Selectable
     }
 
     /**
+     * Counts entities by a set of critieria.
+     *
+     * NOTE: this is not part of the official interface; there's
+     * a Doctrine-internal TODO to make it so.
+     *
+     * @param array<string, mixed> $criteria
+     */
+    public function count(array $criteria): int
+    {
+        return count($this->findBy($criteria));
+    }
+
+    /**
      * Finds a single object by a set of criteria.
      *
      * @param mixed[] $criteria The criteria.

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -74,6 +74,18 @@ class InMemoryRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('2@example.com', $results[1]->getEmail());
     }
 
+    public function testCount(): void
+    {
+        $repo = $this->getFixture();
+        self::assertSame(5, $repo->count([]));
+        self::assertSame(2, $repo->count(['lastName' => 'last']));
+        self::assertSame(3, $repo->count(['lastName' => 'other']));
+        self::assertSame(1, $repo->count(['email' => '1@example.com', 'lastName' => 'last']));
+        self::assertSame(0, $repo->count(['email' => '1@example.com', 'lastName' => 'other']));
+        self::assertSame(1, $repo->count(['email' => '1@example.com']));
+        self::assertSame(0, $repo->count(['email' => '6@example.com']));
+    }
+
     public function testFindByWithArrayValue(): void
     {
         $repo = $this->getFixture();


### PR DESCRIPTION
There's a non-interface method (that's noted as "add to interface in next major version" internally) to get a count of a result set. This adds the same to Mocktrine.