### PR TITLE
Update to only current+upcoming PHP versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,10 @@ jobs:
           - 'high'
           - 'low'
         php:
-          - '7.4'
-          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4-dev'
 
     steps:
       - name: Check out code

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,11 @@
     "description": "PHPUnit Doctrine mocking tools",
     "type": "library",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "doctrine/annotations": "^1.10 || ^2.0",
         "doctrine/collections": "^1.6.8 || ^2.0",
         "doctrine/orm": "^2.9",
-        "doctrine/persistence": "^1.3 || ^2.0 || ^3.0",
-        "symfony/polyfill-php80": "^1.20"
+        "doctrine/persistence": "^1.3 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
Drops 7.4+8.0 and a polyfill dependency to support them.