### PR TITLE
Update supported PHP versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,11 @@ jobs:
           - 'high'
           - 'low'
         php:
-          - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4-dev'
+          - '8.4'
+          - '8.5'
+          - '8.6-dev'
 
     steps:
       - name: Check out code

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHPUnit Doctrine mocking tools",
     "type": "library",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "doctrine/annotations": "^1.10 || ^2.0",
         "doctrine/collections": "^1.6.8 || ^2.0",
         "doctrine/orm": "^2.9",

--- a/tests/InMemoryEntityManagerTest.php
+++ b/tests/InMemoryEntityManagerTest.php
@@ -191,9 +191,6 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testGeneratedReadonlyIdWorks(): void
     {
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $this->markTestSkipped('Readonly properties need 8.1+');
-        }
         $rgid = new Entities\ReadonlyGeneratedId();
         $em = $this->getEntityManager();
         $em->persist($rgid);
@@ -203,9 +200,6 @@ class InMemoryEntityManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testConstructorAssignedReadonlyIdWorks(): void
     {
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $this->markTestSkipped('Readonly properties need 8.1+');
-        }
         $rgid = new Entities\ReadonlyConstructorId();
         $em = $this->getEntityManager();
         $em->persist($rgid);


### PR DESCRIPTION
I'm aware that 8.2 is already EOL as of writing, but there's not really any 8.3-specific features that the library really needs so there's little reason to drop it. 8.2 minimum eliminates the last version_compare checks (readonly properties).

Tests on all current versions plus next upcoming.