### PR TITLE
Fix deprecation warning with no-op PHP

### DIFF
--- a/src/CriteriaEvaluator.php
+++ b/src/CriteriaEvaluator.php
@@ -59,9 +59,7 @@ class CriteriaEvaluator
         $className = $metadata->getName();
         $rc = new ReflectionClass($className);
         foreach ($metadata->getFieldNames() as $fieldName) {
-            $rp = $rc->getProperty($fieldName);
-            $rp->setAccessible(true);
-            $this->reflectionProperties[$fieldName] = $rp;
+            $this->reflectionProperties[$fieldName] = $rc->getProperty($fieldName);
         }
     }
 

--- a/src/InMemoryEntityManager.php
+++ b/src/InMemoryEntityManager.php
@@ -220,7 +220,6 @@ class InMemoryEntityManager implements EntityManagerInterface
             $idField = $repo->getIdField();
             $idType = $repo->getIdType();
             $rp = new \ReflectionProperty($className, $idField);
-            $rp->setAccessible(true);
             foreach ($entities as $entity) {
                 if (!$rp->isInitialized($entity) || $rp->getValue($entity) === null) {
                     $id = random_int(0, PHP_INT_MAX);


### PR DESCRIPTION
ReflectionProperty->setAccessible() has evidently been a no-op since 8.1. Remove calls to it, since this is 8.2+.