### PR TITLE
Fix findOneBy ignoring orderBy parameter

### DIFF
--- a/src/InMemoryRepository.php
+++ b/src/InMemoryRepository.php
@@ -226,7 +226,7 @@ class InMemoryRepository extends EntityRepository implements ObjectRepository, S
      */
     public function findOneBy(array $criteria, ?array $orderBy = null): ?object
     {
-        $results = $this->findBy($criteria);
+        $results = $this->findBy($criteria, $orderBy, limit: 1);
         if (count($results) > 0) {
             return current($results);
         }

--- a/tests/InMemoryRepositoryTest.php
+++ b/tests/InMemoryRepositoryTest.php
@@ -210,6 +210,19 @@ class InMemoryRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('last', $entity->getLastName());
     }
 
+    public function testFindOneByRespectsOrderBy(): void
+    {
+        $repo = $this->getFixture();
+
+        $entityAsc = $repo->findOneBy(['lastName' => 'last'], ['email' => 'ASC']);
+        self::assertNotNull($entityAsc, 'Should find a matching entity');
+        self::assertSame('1@example.com', $entityAsc->getEmail(), 'ASC should return first by email');
+
+        $entityDesc = $repo->findOneBy(['lastName' => 'last'], ['email' => 'DESC']);
+        self::assertNotNull($entityDesc, 'Should find a matching entity');
+        self::assertSame('2@example.com', $entityDesc->getEmail(), 'DESC should return last by email');
+    }
+
     public function testFindWhereIdExists(): void
     {
         $repo = $this->getFixture();


### PR DESCRIPTION
## Summary
- `findOneBy()` accepts an `$orderBy` parameter but was not passing it to `findBy()`, causing the ordering to be ignored when multiple entities match
- Now correctly passes `$orderBy` and `limit: 1` to `findBy()`

## Test plan
- [x] Added test `testFindOneByRespectsOrderBy` that verifies ASC/DESC ordering returns the expected entity
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)